### PR TITLE
Fix: Validate task status input

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,6 +39,9 @@ def list_tasks():
             print(f"[{row[0]}] {row[1]} ({row[2]}) - Created at {row[3]}")
 
 def update_task_status(task_id, new_status):
+    if new_status not in ['pending', 'done']:
+        print("❌ Invalid status. Please use 'pending' or 'done'.")
+        return
     conn = sqlite3.connect(DB_FILE)
     c = conn.cursor()
     c.execute("SELECT * FROM tasks WHERE id = ?", (task_id,))


### PR DESCRIPTION
Auto-generated update for issue:

Currently, the task status can be updated to any value. Only 'pending' or 'done' should be allowed to maintain data integrity. Input validation needs to be added when updating task status.